### PR TITLE
Definition of sequencing finished changed

### DIFF
--- a/one_time_scripts/set_old_dates.py
+++ b/one_time_scripts/set_old_dates.py
@@ -40,9 +40,7 @@ def set_prep_dates(lims):
         
 
 def set_seq_dates(lims):
-    process_types = ['CG002 - Illumina Sequencing (HiSeq X)',
-                  'CG002 - Illumina Sequencing (Illumina SBS)',
-                  'AUTOMATED - NovaSeq Run']
+    process_types = ['CG002 - Sequence Aggregation']
     steps = lims.get_processes(type=process_types)
     print(len(steps)) 
     for i, step in enumerate(steps):

--- a/one_time_scripts/set_old_dates.py
+++ b/one_time_scripts/set_old_dates.py
@@ -61,6 +61,7 @@ def set_seq_dates(lims):
                     continue
                 samp.udf['Sequencing Finished'] = date
                 samp.put()
+                print(samp.id)
 
 
 def set_rec_dates(lims):


### PR DESCRIPTION
Fix: The whole production team decided to change the definition of seq finished. The date will be picked from the sequence aggregation step instead.

**How to prepare for test**:
- [x] ssh to hasta, activate clinical_EPPs env
- [x] checkout this branch and install.
- [x] make sure ~/.genologicsrc is pointing to clinical-lims-stage

**How to test**:
- [x] open a screen and run

```
python set_old_dates.py -s
```

**Expected test outcome**:
- [x] Go through some samples and se that the sequencing date is set to the date when sequence aggregation was run.

**Review:**
- [x] reviewed by @sylvinite 
- [x] tests executed by @mayabrandi 
- [ ] "Merge and deploy" approved by 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
