### PR TITLE
one time script to set old methods

### DIFF
--- a/one_time_scripts/set_old_novaseq_methods.py
+++ b/one_time_scripts/set_old_novaseq_methods.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+from __future__ import division
+from argparse import ArgumentParser
+
+from genologics.lims import Lims
+from genologics.config import BASEURI,USERNAME,PASSWORD
+from datetime import datetime
+
+import logging
+import sys
+
+DESC = """
+One time script to set historical methods on nova seq runs. 
+
+Written by Maya Brandi, Science for Life Laboratory, Stockholm, Sweden
+"""
+
+def set_prep_dates(lims):
+    process_types = ['Define Run Format and Calculate Volumes (Nova Seq)']
+    steps = lims.get_processes(type=process_types)
+    print(len(steps))
+    for i, step in enumerate(steps):
+        if not step.date_run:
+            continue
+        after = datetime.strptime('2019-03-25', '%Y-%m-%d').date()
+        before = datetime.strptime('2020-03-10', '%Y-%m-%d').date()
+        step_date = datetime.strptime(step.date_run, '%Y-%m-%d').date()
+        if after <= step_date <= before:
+            print(i)
+            step.udf['Method'] = '1830'
+            step.udf['Version'] =  4
+            step.put() 
+            print('set methond on step', step.id) 
+def main(lims):
+    set_prep_dates(lims)
+
+if __name__ == "__main__":
+    lims = Lims(BASEURI, USERNAME, PASSWORD)
+    main(lims)


### PR DESCRIPTION
A one time script to set old seq metods: https://github.com/Clinical-Genomics/clinical_EPPs/issues/151

**How to prepare for test**:
- [x] ssh to clinical-lims-stage and become glsai user
- [ ] install the branch in the epp_master env.

```
cd /home/glsai/opt/clinical_EPPs
```

**How to test**:
- [x] login to https://clinical-lims-stage.scilifelab.se
- [ ] run `python set_old_novaseq_methods.py`

**Expected test outcome**:
- [x] check one of the steps that were updated with the script. Did it get the new udfs?
https://clinical-lims-stage.scilifelab.se/api/v2/processes/

- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by @mayabrandi 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
