### PR TITLE
Disable SSL verification in Python

### DIFF
--- a/EPPs/glsapiutil.py
+++ b/EPPs/glsapiutil.py
@@ -5,6 +5,16 @@ import sys
 import xml.dom.minidom
 
 from xml.dom.minidom import parseString
+import ssl
+
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    # Legacy Python that doesn't verify HTTPS certificates by default
+    pass
+else:
+    # Handle target environment that doesn't support HTTPS verification
+    ssl._create_default_https_context = _create_unverified_https_context
 
 DEBUG = 0
 


### PR DESCRIPTION
SSL verification in Python are breaking due to upgraded certificates. This is a temporar fix to the problem. Must be solved in another way. A issue is created #160 




