### PR TITLE
Update qPCR_dilution.py

### DIFF
--- a/EPPs/qPCR_dilution.py
+++ b/EPPs/qPCR_dilution.py
@@ -308,7 +308,7 @@ class PerArtifact():
                 else:
                     self.index['2E03'] = int(numpy.argmax(diff_from_mean_2E03))
             else:
-                if self.index['1E03']:
+                if self.index['1E03'] is not None:
                     if control_1E03 and self.index['1E03'] != numpy.argmax(outlyer_1E03):
                         self.log.write('Distance to big. Conflicting outlyers. ')
                         self.failed_sample = True


### PR DESCRIPTION
The bug caused the wile loop in check_distance_find_outlyer to continue forever. The index of 1E03 should only be set if its none.

**Review:**
- [x] tests executed by @mayabrandi 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
