### PR TITLE
Remove unused imports

### DIFF
--- a/EPPs/aliquot_sequencing_microbial.py
+++ b/EPPs/aliquot_sequencing_microbial.py
@@ -9,7 +9,6 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
 import sys
 

--- a/EPPs/archive/LibNorm_calc_vol.py
+++ b/EPPs/archive/LibNorm_calc_vol.py
@@ -6,9 +6,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 
 DESC = """epp script to calculate EB Volume from Concentration udf

--- a/EPPs/archive/aggregate_QC_n_copy_fields.py
+++ b/EPPs/archive/aggregate_QC_n_copy_fields.py
@@ -6,7 +6,6 @@ from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process, Artifact
 
-import logging
 import sys
 
 
@@ -60,7 +59,6 @@ class CopyUDF():
                             art.udf[udf] = float(value)
                         except:
                             art.udf[udf] = str(value)
-                            pass
 
                         if art.udf.get(udf) is None:
                             self.failed_udfs.append(art.name)

--- a/EPPs/archive/aliquot_for_lib_pool.py
+++ b/EPPs/archive/aliquot_for_lib_pool.py
@@ -6,9 +6,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 
 DESC = """epp script to calculate EB Volume from Concentration udf

--- a/EPPs/archive/amount2qc.py
+++ b/EPPs/archive/amount2qc.py
@@ -10,7 +10,6 @@ from argparse import ArgumentParser
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 from genologics.entities import Process
-from genologics.epp import EppLogger
 from genologics.epp import set_field
 import logging
 import sys

--- a/EPPs/archive/calc_h20_RNA.py
+++ b/EPPs/archive/calc_h20_RNA.py
@@ -10,9 +10,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 
 class EBVolume():

--- a/EPPs/archive/calc_vol.py
+++ b/EPPs/archive/calc_vol.py
@@ -10,9 +10,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 
 class EBVolume():

--- a/EPPs/archive/concentration2qc.py
+++ b/EPPs/archive/concentration2qc.py
@@ -13,7 +13,6 @@ from argparse import ArgumentParser
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 from genologics.entities import Process
-from genologics.epp import EppLogger
 from genologics.epp import set_field
 import logging
 import sys

--- a/EPPs/archive/copyUDFs_from_aggregateQC.py
+++ b/EPPs/archive/copyUDFs_from_aggregateQC.py
@@ -6,9 +6,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 
 

--- a/EPPs/archive/copyUDFs_from_aggregateQC_or_other.py
+++ b/EPPs/archive/copyUDFs_from_aggregateQC_or_other.py
@@ -6,7 +6,6 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
 import logging
 import sys

--- a/EPPs/archive/copy_field_samp2art.py
+++ b/EPPs/archive/copy_field_samp2art.py
@@ -6,9 +6,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 
 

--- a/EPPs/archive/get_EB_vol.py
+++ b/EPPs/archive/get_EB_vol.py
@@ -6,9 +6,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 
 DESC = """epp script to calculate EB Volume from Concentration udf

--- a/EPPs/archive/get_average_size.py
+++ b/EPPs/archive/get_average_size.py
@@ -6,9 +6,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 import numpy as np
 

--- a/EPPs/archive/get_missing_reads.py
+++ b/EPPs/archive/get_missing_reads.py
@@ -6,10 +6,8 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 from clinical_EPPs.config import CG_URL
 from clinical_EPPs.cg_face import CgFace
-import logging
 import sys
 
 DESC = """Epp script to calculate calculate Missing Reads, set the Rerun check box and set the Sequencing QC flag.

--- a/EPPs/archive/get_volumes_from_buffer_twist.py
+++ b/EPPs/archive/get_volumes_from_buffer_twist.py
@@ -6,10 +6,8 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
 import sys
-import os
 
 DESC = """Getting Volume Elution from previous step of type defined by process_types.
     If volume found, setting the value Volume udf on artifact of current step."""

--- a/EPPs/archive/glsapiutil.py
+++ b/EPPs/archive/glsapiutil.py
@@ -554,7 +554,6 @@ class stepOutput:
         self.__type = ""
         self.__isShared = False
         self.__props = {}
-        pass
 
     def setInputLUID(self, value): self.__inputLUID = value
     def getInputLUID(self): return self.__inputLUID
@@ -647,7 +646,6 @@ class stepHelper:
         self.__processDOM = None
         self.__poolingDOM = None
         self.__reagentsDOM = None
-        pass
 
     def setStepURI( self, value ): self.__stepURI = value
     def setAPIHandler(self, object ): self.__APIHandler = object

--- a/EPPs/archive/invoice.py
+++ b/EPPs/archive/invoice.py
@@ -1,19 +1,13 @@
 #!/usr/bin/env python
-import os
 import sys
-import logging
 
 import xlsxwriter
 from argparse import ArgumentParser
 from genologics.lims import Lims
 from genologics.config import BASEURI, USERNAME, PASSWORD
 from genologics.entities import Process
-from genologics.epp import EppLogger
-from genologics.epp import set_field
 
-from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
-from clinicaladmin.database import db, app, ApplicationDetails, ApplicationTagData, MethodDescription, Customers, Invoice
+from clinicaladmin.database import ApplicationDetails, Customers, Invoice
 from clinical_EPPs.invoice_templates import InvoiceTemplate
 
 from datetime import date

--- a/EPPs/archive/molar_concentration.py
+++ b/EPPs/archive/molar_concentration.py
@@ -14,7 +14,6 @@ from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
 
-import logging
 import sys
 
 

--- a/EPPs/archive/reads_aggregation_rml.py
+++ b/EPPs/archive/reads_aggregation_rml.py
@@ -6,11 +6,8 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
-import os
 
 
 DESC = """

--- a/EPPs/archive/set_udf_from_excel.py
+++ b/EPPs/archive/set_udf_from_excel.py
@@ -6,19 +6,10 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-from openpyxl import load_workbook
-import json
-from statistics import mean, median
-import numpy
-from clinical_EPPs import WELL_TRANSFORMER
 import pandas as pd
-from pandas import ExcelWriter
-from pandas import ExcelFile
 
 
-import logging
 import sys
 
 DESC = """epp script to ...

--- a/EPPs/art_hist.py
+++ b/EPPs/art_hist.py
@@ -2,7 +2,7 @@
 from argparse import ArgumentParser
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD,VERSION
-from genologics.entities import Process, Artifact
+from genologics.entities import Process
 import sys
 
 DESC="""script to make hist_dict...."""

--- a/EPPs/bcl2fastq.py
+++ b/EPPs/bcl2fastq.py
@@ -5,21 +5,16 @@ from argparse import ArgumentParser
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 from clinical_EPPs.config import SQLALCHEMY_DATABASE_URI
-
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
 import sys
-
-from BeautifulSoup import BeautifulSoup, Comment
 
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import (Column, Integer, String, DateTime, Text, Enum,
-                        ForeignKey, UniqueConstraint, Numeric, Date)
+                        ForeignKey, UniqueConstraint, Numeric)
 from sqlalchemy.orm import relationship, backref
 
-import os
 
 
 DESC = """

--- a/EPPs/check_duplicate_samples.py
+++ b/EPPs/check_duplicate_samples.py
@@ -6,7 +6,6 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-import logging
 import sys
 
 DESC = """EPP script to check for duplicate samples in a step.

--- a/EPPs/check_indexes_before_aliquot.py
+++ b/EPPs/check_indexes_before_aliquot.py
@@ -5,10 +5,8 @@ from argparse import ArgumentParser
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
-from genologics.entities import Process, ReagentType
-from genologics.epp import EppLogger
+from genologics.entities import Process
 
-import logging
 import sys
 
 DESC = """epp script to check for duplicate indexes in step

--- a/EPPs/check_indexes_in_pools.py
+++ b/EPPs/check_indexes_in_pools.py
@@ -5,10 +5,8 @@ from argparse import ArgumentParser
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
-from genologics.entities import Process, ReagentType
-from genologics.epp import EppLogger
+from genologics.entities import Process
 
-import logging
 import sys
 
 DESC = """epp script to check for duplicate indexes in pools. Comparing sequences. Not index names. 

--- a/EPPs/copy_field_art2samp.py
+++ b/EPPs/copy_field_art2samp.py
@@ -6,7 +6,6 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
 import sys
 

--- a/EPPs/copy_orig_well_art2samp.py
+++ b/EPPs/copy_orig_well_art2samp.py
@@ -6,8 +6,6 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
-import logging
 import sys
 
 DESC = """

--- a/EPPs/denaturate_nova_xp.py
+++ b/EPPs/denaturate_nova_xp.py
@@ -7,7 +7,6 @@ from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
 
-import sys
 
 DESC = """Script to set denaturation volumes for NovaSeq Xp, based on flowcell type.
 The script is taylored for the Xp Denature & ExAmp step in the NovaSeq WF.

--- a/EPPs/make_MAF_plate_layout.py
+++ b/EPPs/make_MAF_plate_layout.py
@@ -9,7 +9,6 @@ from genologics.entities import Process
 
 import logging
 import sys
-import os
 
 
 

--- a/EPPs/make_MAF_sample_table.py
+++ b/EPPs/make_MAF_sample_table.py
@@ -9,7 +9,6 @@ from genologics.entities import Process
 
 import logging
 import sys
-import os
 
 
 

--- a/EPPs/make_bravo_csv.py
+++ b/EPPs/make_bravo_csv.py
@@ -6,9 +6,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 import csv
 

--- a/EPPs/make_twist_pooling_map.py
+++ b/EPPs/make_twist_pooling_map.py
@@ -7,7 +7,6 @@ from genologics.entities import Process
 
 from datetime import date
 
-from art_hist import make_hist_dict_no_stop, make_hist_dict
 import sys
 
 DESC = """

--- a/EPPs/qPCR_dilution.py
+++ b/EPPs/qPCR_dilution.py
@@ -6,19 +6,13 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-from openpyxl import load_workbook
-import json
-from statistics import mean, median
+from statistics import mean
 import numpy
 from clinical_EPPs import WELL_TRANSFORMER
 import pandas as pd
-from pandas import ExcelWriter
-from pandas import ExcelFile
 
 
-import logging
 import sys
 
 DESC = """epp script to ...

--- a/EPPs/qPCR_dilution_wgs_dev.py
+++ b/EPPs/qPCR_dilution_wgs_dev.py
@@ -6,19 +6,13 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-from openpyxl import load_workbook
-import json
-from statistics import mean, median
+from statistics import mean
 import numpy
 from clinical_EPPs import WELL_TRANSFORMER
 import pandas as pd
-from pandas import ExcelWriter
-from pandas import ExcelFile
 
 
-import logging
 import sys
 
 DESC = """epp script to ...

--- a/EPPs/qc2udf_art2samp.py
+++ b/EPPs/qc2udf_art2samp.py
@@ -6,9 +6,7 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
-import logging
 import sys
 
 DESC = """epp script to set a sample udf, based on artifact qc-flagg

--- a/EPPs/reads_aggregation.py
+++ b/EPPs/reads_aggregation.py
@@ -6,10 +6,8 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 
 from genologics.entities import Process
-from genologics.epp import EppLogger
 
 import sys
-import os
 
 DESC = """
 """
@@ -77,7 +75,6 @@ class SumReads():
                 self.passed_samps +=1
             except:
                 self.failed_samps +=1
-                pass
 
 class PoolsAndSamples():
     def __init__(self, process):

--- a/EPPs/set_qc.py
+++ b/EPPs/set_qc.py
@@ -13,9 +13,6 @@ from argparse import ArgumentParser
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 from genologics.entities import Process, Artifact
-from genologics.epp import EppLogger
-from genologics.epp import set_field
-import logging
 import sys
 
 

--- a/clinical_EPPs/check_configuration.py
+++ b/clinical_EPPs/check_configuration.py
@@ -3,7 +3,6 @@ from argparse import ArgumentParser
 
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
-import sys
 import csv
 
 import logging

--- a/one_time_scripts/set_old_dates.py
+++ b/one_time_scripts/set_old_dates.py
@@ -6,8 +6,6 @@ from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 from datetime import datetime
 
-import logging
-import sys
 
 DESC = """
 One time script to set historical dates on samples. 

--- a/one_time_scripts/set_old_novaseq_methods.py
+++ b/one_time_scripts/set_old_novaseq_methods.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 from __future__ import division
-from argparse import ArgumentParser
 
 from genologics.lims import Lims
 from genologics.config import BASEURI,USERNAME,PASSWORD
 from datetime import datetime
 
-import logging
-import sys
 
 DESC = """
 One time script to set historical methods on nova seq runs. 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 from distutils.core import setup
 import glob
-import os
 
 setup(name='clinical_EPPs',
         version='1.0',


### PR DESCRIPTION
This PR removes all unused imports in the project. Having unused imports is a dispensable code smell ([dead code](https://refactoring.guru/smells/dead-code)). The imports were removed with
```
autoflake --remove-all-unused-imports -i -r .  
```

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
